### PR TITLE
Fixed my bad in corejet-to-python.xsl

### DIFF
--- a/corejet/core/xslt/corejet-to-python.xsl
+++ b/corejet/core/xslt/corejet-to-python.xsl
@@ -11,17 +11,17 @@ from corejet.core import Scenario, story, scenario, given, when, then
 @story(id="<xsl:value-of select="@id"/>", title="<xsl:value-of select="@title"/>")
 class <xsl:value-of select="translate(@title, concat(' ', translate(@title, $w, '')), '_')"/>(unittest.TestCase):
 <xsl:for-each select="given">
-    @given("<xsl:value-of select="translate(text(), '&quot;', &quot;'&quot;)"/>")
+    @given("<xsl:value-of select="text()"/>")
     def <xsl:value-of select="translate(text(), concat(' ', translate(text(), $w, '')), '_')"/>(self):
         pass
 </xsl:for-each>
 <xsl:for-each select="when">
-    @when("<xsl:value-of select="translate(text(), '&quot;', &quot;'&quot;)"/>")
+    @when("<xsl:value-of select="text()"/>")
     def <xsl:value-of select="translate(text(), concat(' ', translate(text(), $w, '')), '_')"/>(self):
         pass
 </xsl:for-each>
 <xsl:for-each select="then">
-    @then("<xsl:value-of select="translate(text(), '&quot;', &quot;'&quot;)"/>")
+    @then("<xsl:value-of select="text()"/>")
     def <xsl:value-of select="translate(text(), concat(' ', translate(text(), $w, '')), '_')"/>(self):
         self.assertTrue(False, "This test needs to be finished.")
 </xsl:for-each>
@@ -32,17 +32,17 @@ class <xsl:value-of select="translate(@title, concat(' ', translate(@title, $w, 
     @scenario("<xsl:value-of select="@name"/>")
     class <xsl:value-of select="translate(@name, concat(' ', translate(@name, $w, '')), '_')"/>(Scenario):
 <xsl:for-each select="given">
-        @given("<xsl:value-of select="translate(text(), '&quot;', &quot;'&quot;)"/>")
+        @given("<xsl:value-of select="text()"/>")
         def <xsl:value-of select="translate(text(), concat(' ', translate(text(), $w, '')), '_')"/>(self):
             pass
 </xsl:for-each>
 <xsl:for-each select="when">
-        @when("<xsl:value-of select="translate(text(), '&quot;', &quot;'&quot;)"/>")
+        @when("<xsl:value-of select="text()"/>")
         def <xsl:value-of select="translate(text(), concat(' ', translate(text(), $w, '')), '_')"/>(self):
             pass
 </xsl:for-each>
 <xsl:for-each select="then">
-        @then("<xsl:value-of select="translate(text(), '&quot;', &quot;'&quot;)"/>")
+        @then("<xsl:value-of select="text()"/>")
         def <xsl:value-of select="translate(text(), concat(' ', translate(text(), $w, '')), '_')"/>(self):
             self.assertTrue(False, "This test needs to be finished.")
 </xsl:for-each>


### PR DESCRIPTION
Replacing quotation marks (") with apostrophes (') in clauses (@given, @when, @then) was a bad idea, because after they have been replaced, they cannot be matched by testrunner anymore (causing mismatches in corejet-reports). I'm sorry. My bad.

Of course, that caused problems only, if one used quotation marks in scenarios.

A possible fix could've been to escape quotation marks like \", but that would'be been ugly with XSLT 1.0.

Instead, I tweaked my corejet.pivotal to replace quotation marks with apostrophes before parsing scenarios.

I'd be happy with that.
