### PR TITLE
Replace quotes with apostrophes when parsing scenarios

### DIFF
--- a/corejet/core/parser.py
+++ b/corejet/core/parser.py
@@ -17,7 +17,7 @@ def appendScenarios(story, text):
     scenario = None
     previousStep = None
     
-    for line in text.splitlines():
+    for line in re.sub('"', "'", text).splitlines():
         
         scenarioMatch = scenario_regex.match(line)
         if scenarioMatch:


### PR DESCRIPTION
Hi, I would not like to completely kill quotes from scenario descriptions.

Therefore I propose two more changes I discussed earlier:

1) canonize all quotes (") to apostrophes (') while parsing scenarios

2) fix corejet.visualization to create javascript, which allows apostrophes in strings.

This patch does 1), but you may prefer some other method to do that.
