### PR TITLE
Moved quote canonization from parser to model classes to be more complete

### DIFF
--- a/corejet/core/model.py
+++ b/corejet/core/model.py
@@ -155,6 +155,11 @@ class Epic(object):
         self.title = title
         self.stories = stories or []
 
+    def __setattr__(self, name, value):
+        if type(value) in (str, unicode):
+            value = value.replace('"', "'")
+        return super(Epic, self).__setattr__(name, value)
+
 class Story(object):
     implements(IStory)
     
@@ -174,6 +179,11 @@ class Story(object):
         self.priority = priority
         self.epic = epic
 
+    def __setattr__(self, name, value):
+        if type(value) in (str, unicode):
+            value = value.replace('"', "'")
+        return super(Story, self).__setattr__(name, value)
+
 class Scenario(object):
     implements(IScenario)
     
@@ -191,9 +201,19 @@ class Scenario(object):
         self.status = status
         self.story = story
 
+    def __setattr__(self, name, value):
+        if type(value) in (str, unicode):
+            value = value.replace('"', "'")
+        return super(Scenario, self).__setattr__(name, value)
+
 class Step(object):
     implements(IStep)
     
     def __init__(self, text, step_type):
         self.text = text
         self.step_type = step_type
+
+    def __setattr__(self, name, value):
+        if type(value) in (str, unicode):
+            value = value.replace('"', "'")
+        return super(Step, self).__setattr__(name, value)

--- a/corejet/core/parser.py
+++ b/corejet/core/parser.py
@@ -17,7 +17,7 @@ def appendScenarios(story, text):
     scenario = None
     previousStep = None
     
-    for line in re.sub('"', "'", text).splitlines():
+    for line in text.splitlines():
         
         scenarioMatch = scenario_regex.match(line)
         if scenarioMatch:


### PR DESCRIPTION
https://github.com/optilude/corejet.visualization/pull/3#issuecomment-2006627

> How does this work with double quotes in the requirement name?

Of course it doesn't, because replacing quotes in appendScenarios-parser affects only scenarios and their names. Not epics and stories, and it relies on plugin using the parser in the first place :/

Another try. This looks bloated, but something like this (overloading setattr) should cover all cases.
